### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Path parsing library (for Rust)"
 edition = "2021"
-homepage = "https://github.com/synesissoftware/libpath.Rust"
+repository = "https://github.com/synesissoftware/libpath.Rust"
 license = "BSD-3-Clause"
 name = "libpath"
 readme = "README.md"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).